### PR TITLE
Documentation review: plugin-algolia

### DIFF
--- a/src/main/java/io/kestra/plugin/algolia/AbstractAlgoliaTask.java
+++ b/src/main/java/io/kestra/plugin/algolia/AbstractAlgoliaTask.java
@@ -19,7 +19,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 public abstract class AbstractAlgoliaTask<T extends io.kestra.core.models.tasks.Output> extends Task implements RunnableTask<T> {
     @Schema(
-        title = "Provide Algolia Application ID",
+        title = "Algolia Application ID",
         description = "Required; project Application ID from the Algolia dashboard."
     )
     @NotNull
@@ -27,7 +27,7 @@ public abstract class AbstractAlgoliaTask<T extends io.kestra.core.models.tasks.
     protected Property<String> applicationId;
 
     @Schema(
-        title = "Authenticate with Admin API Key",
+        title = "Admin API Key",
         description = "Admin API Key used for search, indexing, and deletes; render from secrets."
     )
     @NotNull

--- a/src/main/java/io/kestra/plugin/algolia/Delete.java
+++ b/src/main/java/io/kestra/plugin/algolia/Delete.java
@@ -45,7 +45,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     applicationId: "{{ secret('ALGOLIA_APP_ID') }}"
                     apiKey: "{{ secret('ALGOLIA_API_KEY') }}"
                     indexName: "products"
-                    objectIDs:
+                    objectIds:
                       - "id_1"
                       - "id_2"
                 """

--- a/src/main/java/io/kestra/plugin/algolia/Search.java
+++ b/src/main/java/io/kestra/plugin/algolia/Search.java
@@ -28,7 +28,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @EqualsAndHashCode
 @Schema(
     title = "Query records in an Algolia index",
-    description = "Runs a search against a single Algolia index with any supported search parameters and returns hits. Uses the Admin API Key; defaults return all records if no params are provided."
+    description = "Runs a search against a single Algolia index with any supported search parameters and returns hits. Uses the Admin API Key. With no params, the empty query matches all records but returns only the first page (Algolia default hitsPerPage=20)."
 )
 @Plugin(
     examples = {
@@ -63,7 +63,7 @@ public class Search extends AbstractAlgoliaTask<Search.Output> implements Runnab
 
     @Schema(
         title = "Search parameters",
-        description = "Any Algolia search params (query, hitsPerPage, filters, facets, etc.). Defaults to empty map, which returns all records with Algolia defaults (hitsPerPage=20)."
+        description = "Any Algolia search params (query, hitsPerPage, filters, facets, etc.). Defaults to an empty map: the empty query matches all records but returns only the first page (Algolia default hitsPerPage=20)."
     )
     @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> params;

--- a/src/main/resources/doc/io.kestra.plugin.algolia.md
+++ b/src/main/resources/doc/io.kestra.plugin.algolia.md
@@ -4,7 +4,7 @@ Index, search, and delete records in Algolia from Kestra flows.
 
 ## Authentication
 
-Set `applicationId` to your Algolia application ID and `apiKey` to your API key (both required). Store secrets in [secrets](https://kestra.io/docs/concepts/secret) and apply connection properties globally with [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults).
+Set `applicationId` to your Algolia application ID and `apiKey` to your Algolia Admin API Key (both required). Store secrets in [secrets](https://kestra.io/docs/concepts/secret) and apply connection properties globally with [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults).
 
 ## Tasks
 


### PR DESCRIPTION
## Documentation review: plugin-algolia

Documentation-only pass over the 3 tasks (`Index`, `Search`, `Delete`), the abstract base, the
plugin how-to doc, and metadata. Task inventory cross-checked against the Kestra plugin registry
(3 tasks, matches). No behavior, validation, or UI-layout changes.

4 files changed.

### Fixed — correctness
- **`Delete` example used the wrong property name:** `objectIDs:` → `objectIds:` to match the
  actual `objectIds` property. As written, the example would fail to bind (`@NotNull` violation).
- **`Search` "returns all records" clarified:** with no `params`, the empty query matches all
  records but returns only the first page (Algolia default `hitsPerPage=20`) — corrected the class
  and `params` descriptions, which implied all records are returned.

### Fixed — style / consistency
- **`AbstractAlgoliaTask` titles** changed from imperative phrases to noun labels:
  "Provide Algolia Application ID" → "Algolia Application ID"; "Authenticate with Admin API Key" →
  "Admin API Key".
- **Doc Authentication:** clarified `apiKey` is the Algolia **Admin** API Key (required for index
  and delete), matching the task/property descriptions.
